### PR TITLE
agda: Add agda packages to release test set

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -189,6 +189,7 @@ let
       haskell.compiler = packagePlatforms pkgs.haskell.compiler;
       haskellPackages = packagePlatforms pkgs.haskellPackages;
       idrisPackages = packagePlatforms pkgs.idrisPackages;
+      agda = packagePlatforms pkgs.agda;
 
       # Language packages disabled in https://github.com/NixOS/nixpkgs/commit/ccd1029f58a3bb9eca32d81bf3f33cb4be25cc66
 


### PR DESCRIPTION
This causes three of the four agda packages to be included in the release tests.  I verify that all three of them pass on x86_64-linux: agda-prelude, iowa-stdlib, standard-library.


(
agda-categories is excluded because it sets `hydraPlatforms = []`.  When I try it anyway (by removing its `hydraPlatforms = []`), I get this error:
``` 
/build/source/Categories/Morphism/Isomorphism.agda:170,41-51
Function does not accept argument {i = _}
when checking that {i = _
```
)