### PR TITLE
agda: Move hashes & versions out of top-level

### DIFF
--- a/pkgs/development/libraries/agda/agda-categories/default.nix
+++ b/pkgs/development/libraries/agda/agda-categories/default.nix
@@ -1,21 +1,18 @@
-{ lib, mkDerivation, fetchFromGitHub, standard-library, version, sha256 }:
+{ lib, mkDerivation, fetchFromGitHub, standard-library_1_1 }:
 
-mkDerivation {
-  inherit version;
+mkDerivation rec {
+  version = "0.1";
   pname = "agda-categories";
 
   src = fetchFromGitHub {
     owner = "agda";
     repo = "agda-categories";
     rev = "release/v${version}";
-    inherit sha256;
+    sha256 = "0m4pjy92jg6zfziyv0bxv5if03g8k4413ld8c3ii2xa8bzfn04m2";
   };
 
   # Does not work with standard-library 1.2
-  buildInputsAgda = [ (standard-library.override {
-    version = "1.1";
-    sha256 = "190bxsy92ffmvwpmyyg3lxs91vyss2z25rqz1w79gkj56484cy64";
-  }) ];
+  buildInputsAgda = [ standard-library_1_1 ];
 
   meta = with lib; {
     inherit (src.meta) homepage;

--- a/pkgs/development/libraries/agda/agda-prelude/default.nix
+++ b/pkgs/development/libraries/agda/agda-prelude/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, mkDerivation, fetchFromGitHub, version, sha256 }:
+{ stdenv, mkDerivation, fetchFromGitHub }:
 
-mkDerivation {
-  inherit version;
+mkDerivation rec {
   pname = "agda-prelude";
+  version = "compat-2.6.0";
 
   src = fetchFromGitHub {
     owner = "UlfNorell";
     repo = "agda-prelude";
     rev = version;
-    inherit sha256;
+    sha256 = "16pysyq6nf37zk9js4l5gfd2yxgf2dh074r9507vqkg6vfhdj2w6";
   };
 
   preConfigure = ''

--- a/pkgs/development/libraries/agda/iowa-stdlib/default.nix
+++ b/pkgs/development/libraries/agda/iowa-stdlib/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, mkDerivation, fetchFromGitHub, version, sha256 }:
+{ stdenv, mkDerivation, fetchFromGitHub }:
 
-mkDerivation {
-  inherit version;
+mkDerivation rec {
   pname = "iowa-stdlib";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "cedille";
     repo  = "ial";
     rev = "v${version}";
-    inherit sha256;
+    sha256 = "0dlis6v6nzbscf713cmwlx8h9n2gxghci8y21qak3hp18gkxdp0g";
   };
 
   libraryFile = "";

--- a/pkgs/development/libraries/agda/standard-library/1.1.nix
+++ b/pkgs/development/libraries/agda/standard-library/1.1.nix
@@ -1,0 +1,26 @@
+{ stdenv, mkDerivation, fetchFromGitHub, ghcWithPackages }:
+
+mkDerivation rec {
+  pname = "standard-library";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    repo = "agda-stdlib";
+    owner = "agda";
+    rev = "v${version}";
+    sha256 = "190bxsy92ffmvwpmyyg3lxs91vyss2z25rqz1w79gkj56484cy64";
+  };
+
+  nativeBuildInputs = [ (ghcWithPackages (self : [ self.filemanip ])) ];
+  preConfigure = ''
+    runhaskell GenerateEverything.hs
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://wiki.portal.chalmers.se/agda/pmwiki.php?n=Libraries.StandardLibrary;
+    description = "A standard library for use with the Agda compiler";
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with maintainers; [ jwiegley mudri alexarice ];
+  };
+}

--- a/pkgs/development/libraries/agda/standard-library/1.2.nix
+++ b/pkgs/development/libraries/agda/standard-library/1.2.nix
@@ -1,13 +1,14 @@
-{ stdenv, mkDerivation, fetchFromGitHub, ghcWithPackages, version, sha256 , rev ? "v${version}" }:
+{ stdenv, mkDerivation, fetchFromGitHub, ghcWithPackages }:
 
-mkDerivation {
+mkDerivation rec {
   pname = "standard-library";
-  inherit version;
+  version = "1.2";
 
   src = fetchFromGitHub {
     repo = "agda-stdlib";
     owner = "agda";
-    inherit sha256 rev;
+    rev = "v${version}";
+    sha256 = "01v4dy0ckir9skrn118ca4mzjnwdas70q9a9lncawjblwzikg4hq";
   };
 
   nativeBuildInputs = [ (ghcWithPackages (self : [ self.filemanip ])) ];

--- a/pkgs/top-level/agda-packages.nix
+++ b/pkgs/top-level/agda-packages.nix
@@ -4,32 +4,27 @@ let
   mkAgdaPackages = Agda: lib.makeScope newScope (mkAgdaPackages' Agda);
   mkAgdaPackages' = Agda: self: let
     callPackage = self.callPackage;
-  in {
+  in rec {
     inherit Agda;
     inherit (callPackage ../build-support/agda {
       inherit Agda self;
       inherit (pkgs.haskellPackages) ghcWithPackages;
     }) withPackages mkDerivation;
 
-    standard-library = callPackage ../development/libraries/agda/standard-library {
+    standard-library_1_1 = callPackage ../development/libraries/agda/standard-library/1.1.nix {
       inherit (pkgs.haskellPackages) ghcWithPackages;
-      version = "1.2";
-      sha256 = "01v4dy0ckir9skrn118ca4mzjnwdas70q9a9lncawjblwzikg4hq";
     };
 
-    iowa-stdlib = callPackage ../development/libraries/agda/iowa-stdlib {
-      version = "1.5.0";
-      sha256 = "0dlis6v6nzbscf713cmwlx8h9n2gxghci8y21qak3hp18gkxdp0g";
+    standard-library_1_2 = callPackage ../development/libraries/agda/standard-library/1.2.nix {
+      inherit (pkgs.haskellPackages) ghcWithPackages;
     };
 
-    agda-prelude = callPackage ../development/libraries/agda/agda-prelude {
-      version = "compat-2.6.0";
-      sha256 = "16pysyq6nf37zk9js4l5gfd2yxgf2dh074r9507vqkg6vfhdj2w6";
-    };
+    standard-library = standard-library_1_2;
 
-    agda-categories = callPackage ../development/libraries/agda/agda-categories {
-      version = "0.1";
-      sha256 = "0m4pjy92jg6zfziyv0bxv5if03g8k4413ld8c3ii2xa8bzfn04m2";
-    };
+    iowa-stdlib = callPackage ../development/libraries/agda/iowa-stdlib { };
+
+    agda-prelude = callPackage ../development/libraries/agda/agda-prelude { };
+
+    agda-categories = callPackage ../development/libraries/agda/agda-categories { };
   };
 in mkAgdaPackages Agda


### PR DESCRIPTION
Let's use the version-number-appended-to-name convention.  This way, all the standard libraries are still found in libraries/agda/standard-library/, well-behaved consumers can still use the plain name, churn in top-level/ is minimized, and git-log history spelunkers can get the record of package versions & hashes separately rather than everything being mixed together in top-level.

This convention is used for ~60 other packages: `egrep '^  ([^ ]*) = \1[-_][0-9]' pkgs/top-level/*`